### PR TITLE
feat : 만료된 토큰 갱신 구현 #4

### DIFF
--- a/src/main/java/dnd/project/dnd6th7worryrecordservice/config/WebConfig.java
+++ b/src/main/java/dnd/project/dnd6th7worryrecordservice/config/WebConfig.java
@@ -2,6 +2,8 @@ package dnd.project.dnd6th7worryrecordservice.config;
 
 import dnd.project.dnd6th7worryrecordservice.jwt.JwtInterceptor;
 import dnd.project.dnd6th7worryrecordservice.jwt.JwtUtil;
+import dnd.project.dnd6th7worryrecordservice.service.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -10,13 +12,15 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@RequiredArgsConstructor
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+    private final UserService userService;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         System.out.println("####### Register Interceptor: JwtInterceptor!!!");
-        registry.addInterceptor(jwtInterceptor()).addPathPatterns("/qss/**");   //토큰을 검증할 path
+        registry.addInterceptor(jwtInterceptor()).addPathPatterns("/auth/validTest");   //토큰을 검증할 path
     }
 
     @Override
@@ -28,5 +32,5 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Bean
     public JwtInterceptor jwtInterceptor() {
-        return new JwtInterceptor(); }
+        return new JwtInterceptor(userService); }
 }

--- a/src/main/java/dnd/project/dnd6th7worryrecordservice/controller/KakaoController.java
+++ b/src/main/java/dnd/project/dnd6th7worryrecordservice/controller/KakaoController.java
@@ -33,7 +33,7 @@ public class KakaoController {
 
             TokenDto tokens = jwtUtil.createToken(userInfo);
             userInfo.setRefreshToken(tokens.getJwtRefreshToken());
-
+            //kakaoId 기준으로 User 데이터가 없으면 Insert, 있으면 Update
             userService.insertOrUpdateUser(userInfo);
 
             res.addHeader("at-jwt-access-token",tokens.getJwtAccessToken());

--- a/src/main/java/dnd/project/dnd6th7worryrecordservice/domain/user/UserRepository.java
+++ b/src/main/java/dnd/project/dnd6th7worryrecordservice/domain/user/UserRepository.java
@@ -21,5 +21,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("UPDATE User u SET u.username = ?1, u.email = ?2, u.imgUrl = ?3, u.refreshToken = ?4 WHERE u.kakaoId = ?5")
     void updateUserByKakaoId(String username, String email, String imgURL, String refreshToken, String kakaoId);
 
+    @Query("SELECT u.refreshToken FROM User u WHERE u.kakaoId = ?1")
+    String findRefreshTokenByKakaoId(String kakaoId);
+
 }
 

--- a/src/main/java/dnd/project/dnd6th7worryrecordservice/dto/UserRequestDto.java
+++ b/src/main/java/dnd/project/dnd6th7worryrecordservice/dto/UserRequestDto.java
@@ -25,7 +25,7 @@ public class UserRequestDto {
         this.refreshToken = refreshToken;
     }
 
-    //테스트용
+
     public UserRequestDto(String username, String email, String kakaoId, String imgURL) {
         this.username = username;
         this.email = email;

--- a/src/main/java/dnd/project/dnd6th7worryrecordservice/dto/jwt/JwtPayloadDto.java
+++ b/src/main/java/dnd/project/dnd6th7worryrecordservice/dto/jwt/JwtPayloadDto.java
@@ -1,0 +1,19 @@
+package dnd.project.dnd6th7worryrecordservice.dto.jwt;
+
+import dnd.project.dnd6th7worryrecordservice.dto.UserRequestDto;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class JwtPayloadDto {
+    private String username;
+    private String email;
+    private String kakaoId;
+    private String imgURL;
+
+    public UserRequestDto toUserRequestDto(){
+        UserRequestDto userRequestDto = new UserRequestDto(this.username, this.email, this.getKakaoId(), this.getImgURL());
+        return userRequestDto;
+    }
+}

--- a/src/main/java/dnd/project/dnd6th7worryrecordservice/jwt/JwtInterceptor.java
+++ b/src/main/java/dnd/project/dnd6th7worryrecordservice/jwt/JwtInterceptor.java
@@ -1,5 +1,8 @@
 package dnd.project.dnd6th7worryrecordservice.jwt;
 
+import com.google.gson.Gson;
+import dnd.project.dnd6th7worryrecordservice.dto.jwt.JwtPayloadDto;
+import dnd.project.dnd6th7worryrecordservice.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -7,11 +10,13 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-
+@RequiredArgsConstructor
 public class JwtInterceptor implements HandlerInterceptor {
+    private final UserService userService;
 
     @Autowired
     private JwtUtil jwtUtil;
+
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
@@ -19,13 +24,58 @@ public class JwtInterceptor implements HandlerInterceptor {
 
         System.out.println("####### Interceptor preHandle Start!!!");
 
-        String atJwtToken = request.getHeader("at-jwt-access-token");
+        String atJwtAccessToken = request.getHeader("at-jwt-access-token");
+        String atJwtRefreshToken = request.getHeader("at-jwt-refresh-token");
 
-        if(atJwtToken != null && atJwtToken.length() > 0) {
-            if(jwtUtil.validate(atJwtToken)) return true;
-            else throw new IllegalArgumentException("Token Error!!!");
-        }else {
-            throw new IllegalArgumentException("No Token!!!");
+        System.out.println("atJwtAccessToken = " + atJwtAccessToken);
+        System.out.println("atJwtRefreshToken = " + atJwtRefreshToken);
+        System.out.println("request method : " + request.getMethod());
+
+        //preflight 대응
+        if ("OPTIONS".equals(request.getMethod())) {
+            System.out.println("request method is OPTIONS!!");
+            return true;
         }
+
+        //토큰 검증 및 재발급
+
+        //When RefreshToken isn't in HTTP header
+        if (atJwtRefreshToken == null) {
+            //When AccessToken is in HTTP header
+            if (atJwtAccessToken != null && atJwtAccessToken.length() > 0) {
+                //validate AccessToken
+                if (jwtUtil.validate(atJwtAccessToken)) return true;
+                else throw new IllegalArgumentException("Token Error!!!");
+            }//When AccessToken isn't HTTP header
+            else {
+                throw new IllegalArgumentException("No Token!!!");
+            }
+        }//When RefreshToken in HTTP header
+        else{
+            //validate RefreshToken
+            if(jwtUtil.validate(atJwtRefreshToken)){
+                //Decode & Parse AccessToken to JwtPayloadDto
+                String accessTokenPayload = jwtUtil.decodePayload(atJwtAccessToken);
+                Gson gson = new Gson();
+                JwtPayloadDto jwtPayload = gson.fromJson(accessTokenPayload, JwtPayloadDto.class);
+
+                //Compare RefreshToken in DB with RefreshToken in HTTP header
+                String refreshTokenInDB = userService.findRefreshTokenByKakaoId(jwtPayload.getKakaoId());
+
+                if(refreshTokenInDB.equals(atJwtRefreshToken)){
+                    //Create new AccessToken and addHeader
+                    String AccessJws = jwtUtil.createToken(jwtPayload.toUserRequestDto()).getJwtAccessToken();
+                    response.addHeader("at-jwt-access-token", AccessJws);
+                }else {
+                    throw new IllegalArgumentException("Refresh Token Error!!!");
+                }
+
+                return true;
+
+            }else {
+                throw new IllegalArgumentException("Refresh Token Error!!!");
+            }
+        }
+
     }
 }

--- a/src/main/java/dnd/project/dnd6th7worryrecordservice/service/UserService.java
+++ b/src/main/java/dnd/project/dnd6th7worryrecordservice/service/UserService.java
@@ -21,14 +21,11 @@ public class UserService {
 
     public void insertOrUpdateUser(UserRequestDto userRequestDto) {
         String kakaoId = userRequestDto.getKakaoId();
-        System.out.println("kakaoId = " + kakaoId);
         //처음 로그인 하는 유저면 DB에 insert
         if(!findUserByKakaoId(kakaoId).isPresent()){
-            System.out.println("insert");
             User user = userRequestDto.toEntity();  //기본 Role = ROLE.USER
             userRepository.save(user);
         }else{ //이미 로그인 했던 유저라면 DB update
-            System.out.println("update");
             updateUserByKakaoId(userRequestDto);
         }
     }
@@ -40,6 +37,10 @@ public class UserService {
 
     public void updateUserByKakaoId(UserRequestDto userInfo){
         userRepository.updateUserByKakaoId(userInfo.getUsername(), userInfo.getEmail(), userInfo.getImgURL(), userInfo.getRefreshToken(), userInfo.getKakaoId());
+    }
+
+    public String findRefreshTokenByKakaoId(String kakaoId){
+        return userRepository.findRefreshTokenByKakaoId(kakaoId);
     }
 
 

--- a/src/test/java/dnd/project/dnd6th7worryrecordservice/jwt/JwtUtilTest.java
+++ b/src/test/java/dnd/project/dnd6th7worryrecordservice/jwt/JwtUtilTest.java
@@ -1,6 +1,5 @@
 package dnd.project.dnd6th7worryrecordservice.jwt;
 
-import dnd.project.dnd6th7worryrecordservice.config.SecurityConfig;
 import dnd.project.dnd6th7worryrecordservice.dto.UserRequestDto;
 import dnd.project.dnd6th7worryrecordservice.dto.jwt.TokenDto;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -12,9 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import javax.crypto.SecretKey;
@@ -63,6 +59,17 @@ class JwtUtilTest {
 
         jwtUtil.validate(tokens.getJwtAccessToken());
 
+    }
+
+    @Test
+    @DisplayName("decode 테스트")
+    public void decodeTest(){
+        UserRequestDto userRequestDto = new UserRequestDto("username", "abbc@naver.com", "1231234","awdlawdnkawndlknflakwf.com");
+        TokenDto tokens = jwtUtil.createToken(userRequestDto);
+
+        String decode = jwtUtil.decodePayload(tokens.getJwtAccessToken());
+
+        System.out.println("decode = " + decode);
     }
 
 }


### PR DESCRIPTION
FRONT PART
1. Front 에서 카카오에 로그인하여 '인가 코드' 흭득
2. Front 에서 '인가 코드' 사용하여 'AccessToken' 흭득
3. 서버로 'AccessToken' 전송
4.request 시에 token 만료시간(exp) 확인
 - Access Token의 만료시간이 1분이상 남았을 때, Header에 Access Token만 전송
 - Access Token이 만료되었거나 1분이하로 남았을 때, Header에 Refresh Token과 Access Token모두 전송

BACK PART
1. 'AccessToken' 사용하여 유저정보 받아오기 (완료)
2. 유저정보 DB에 저장 (완료)
3. 유저정보 기반으로 JWT AccessToken, RefreshToken 발급하여 return(완료)
4. Refresh Token DB 저장 (완료) - USER 테이블에 저장
5. 만료된 토큰 갱신 (완료)