### PR TITLE
fix: FCM토큰 초기화 시(/auth/refresh) JWT도 초기화 하도록 변경 #2

### DIFF
--- a/src/main/java/dnd/project/dnd6th7worryrecordservice/api/AuthController.java
+++ b/src/main/java/dnd/project/dnd6th7worryrecordservice/api/AuthController.java
@@ -32,7 +32,6 @@ public class AuthController {
 
     @ApiOperation(value = "KAKAO OAuth2 로그인", notes = "카카오 계정으로 로그인 후 ResponseHeader로 JWT AccessToken, RefreshToken 을 발급한다")
     @PostMapping(value = "/kakao")
-    //Token값 헤더로 받도록 변경 필요
     public ResponseEntity<UserResponseDto> kakaoLogin(@RequestHeader("oauthToken") String accessToken, @RequestHeader("deviceToken") String deviceToken, HttpServletResponse res) {
         System.out.println("accessToken = " + accessToken);
 
@@ -107,7 +106,7 @@ public class AuthController {
                     name = "deviceToken"
                     , value = "FCM서버에서 전송 받는 푸쉬알림을 위한 토큰")
     })
-    @PutMapping(value = "/refresh")
+    @PutMapping(value = "/refresh") //프론트에서 JWT at/rt 함께 보내 두 토큰 모두 refresh 하도록 설계
     public ResponseEntity<?> refreshDeviceToken(@RequestParam("userId") Long userId, @RequestParam("deviceToken") String deviceToken) {
         try {
             userService.updateDeviceToken(deviceToken, userId);

--- a/src/main/java/dnd/project/dnd6th7worryrecordservice/config/SecurityConfig.java
+++ b/src/main/java/dnd/project/dnd6th7worryrecordservice/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig
                 .csrf().disable()
                 .authorizeRequests()
                 .antMatchers("/ping").permitAll()
-                .antMatchers("/auth/**").permitAll() // /auth/**에 대한 접근을 인증 절차 없이 허용(로그인 관련 url)
+                .antMatchers("/auth/kakao").permitAll() // auth/kakao 에 대한 접근을 인증 절차 없이 허용(로그인 관련 url)
+                .antMatchers("/auth/apple").permitAll() // auth/apple 에 대한 접근을 인증 절차 없이 허용(로그인 관련 url)
                 .antMatchers("/").permitAll() //메인 화면 접근 가능
                 .antMatchers("/worries/**").hasAnyRole("USER","ADMIN")
                 .anyRequest().authenticated() // 위에서 따로 지정한 접근허용 리소스 설정 후 그 외 나머지 리소스들은 무조건 인증을 완료해야 접근 가능


### PR DESCRIPTION
프론트단에서 JWT at/rt 함께 보내 두 토큰 모두 refresh 하도록 설계해야함.